### PR TITLE
HotFix new API

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-BASE_URL = "http://www.radio-browser.info/webservice/"
+BASE_URL = "https://de1.api.radio-browser.info/"
 
 endpoints = {
     "countries": {1: "{fmt}/countries", 2: "{fmt}/countries/{filter}"},


### PR DESCRIPTION
As written on the homepage `The api endpoints at www.radio-browser.info/webservice will be taken down at August 1. of 2020`. I edited the base Url to make it work again. Could be better implemented as written in the [official documentation](https://api.radio-browser.info/)